### PR TITLE
Automatic GPX Naming

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,6 +43,16 @@ The following options are available:
 - `-r, --recursive`: Search for images recursively in subdirectories
 - `-v, --verbose`: Enable verbose output
 
+### Automatic GPX Naming
+
+If you don't specify an output file with `-o`, PixTrail will automatically name the GPX file after the directory name containing the photos:
+
+```bash
+pixtrail /path/to/Photos-Kyoto
+```
+
+This will create a GPX file named `Photos_Paris.gpx` in the same directory.
+
 ### Examples
 
 Process photos in a directory and save the GPX file to a custom location:

--- a/pixtrail/cli.py
+++ b/pixtrail/cli.py
@@ -68,16 +68,15 @@ def main(args: List[str] = None) -> int:
         print(f"Error: Input directory does not exist: {parsed_args.input_dir}")
         return 1
     
-    # Set output path
+    # Set output path (if not specified, it will be auto-named in process_and_generate)
     output_path = parsed_args.output
-    if not output_path:
-        output_path = os.path.join(parsed_args.input_dir, "track.gpx")
     
-    # Ensure output directory exists
-    output_dir = os.path.dirname(os.path.abspath(output_path))
-    if not ensure_directory(output_dir):
-        print(f"Error: Could not create output directory: {output_dir}")
-        return 1
+    # If output path is provided, ensure its directory exists
+    if output_path:
+        output_dir = os.path.dirname(os.path.abspath(output_path))
+        if not ensure_directory(output_dir):
+            print(f"Error: Could not create output directory: {output_dir}")
+            return 1
     
     try:
         # Create PixTrail object
@@ -96,7 +95,9 @@ def main(args: List[str] = None) -> int:
         )
         
         if success:
-            print(f"GPX file created successfully: {output_path}")
+            # Get the actual output path for display
+            actual_output = output_path if output_path else get_default_output_path(parsed_args.input_dir)
+            print(f"GPX file created successfully: {actual_output}")
             return 0
         else:
             print("Failed to create GPX file")

--- a/pixtrail/core.py
+++ b/pixtrail/core.py
@@ -93,29 +93,29 @@ class PixTrail:
     ) -> bool:
         """
         Process all images in a directory and generate a GPX file.
-        
+    
         Args:
             input_dir: Directory containing image files
-            output_path: Path where the GPX file will be saved
+            output_path: Path where the GPX file will be saved (if None, use automatic naming)
             recursive: Whether to search recursively in subdirectories
-        
+    
         Returns:
             bool: True if the GPX file was generated successfully, False otherwise
         """
         # Process directory
         self.process_directory(input_dir, recursive)
-        
+    
         if not self.gps_data_list:
             return False
-        
-        # Use provided output path or generate a default one
+    
+        # Use provided output path or generate a default one automatically
         final_output_path = output_path
         if not final_output_path:
             final_output_path = get_default_output_path(input_dir)
-        
+    
         # Ensure output directory exists
         output_dir = os.path.dirname(os.path.abspath(final_output_path))
         ensure_directory(output_dir)
-        
+    
         # Generate GPX file
         return self.generate_gpx(final_output_path)

--- a/pixtrail/utils.py
+++ b/pixtrail/utils.py
@@ -62,17 +62,27 @@ def ensure_directory(directory: str) -> bool:
         return False
 
 
-def get_default_output_path(input_dir: str, filename: str = "track.gpx") -> str:
+def get_default_output_path(input_dir: str, filename: str = None) -> str:
     """
     Generate a default output path for the GPX file based on the input directory.
     
     Args:
         input_dir: Input directory path
-        filename: Name of the output file
+        filename: Name of the output file (if None, use directory name)
         
     Returns:
         Default output path for the GPX file
     """
+    if filename is None:
+        # Extract the directory name and use it for the GPX file
+        dir_name = os.path.basename(os.path.normpath(input_dir))
+        # Remove any invalid characters for filenames
+        dir_name = ''.join(c for c in dir_name if c.isalnum() or c in (' ', '_', '-'))
+        filename = f"{dir_name.strip()}.gpx"
+        # If directory name is empty or results in empty filename, use default
+        if not filename or filename == ".gpx":
+            filename = "PixTrail.gpx"
+    
     return os.path.join(input_dir, filename)
 
 


### PR DESCRIPTION
This PR implements the "Automatic GPX Naming" feature that was previously announced in the roadmap. GPX files are now automatically named after the photo directory when no explicit output path is provided. This improves the user experience as you no longer need to manually specify a suitable filename for each directory.

## Changes

- Extended the `get_default_output_path` function in `utils.py` to use the directory name for the output filename
- Adjusted the `process_and_generate` method in `core.py`
- Updated the `main` function in `cli.py` to display the correct path
- Changed the default naming from "track.gpx" to "PixTrail.gpx"
- Extended the documentation in `usage.md` to describe the new feature

## Testing

- Tested with various directory names, including spaces and special characters
- Tested with and without explicit output paths
- Tested with nested directories during recursive processing