### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/pixtrail/web/routes.py
+++ b/pixtrail/web/routes.py
@@ -110,7 +110,8 @@ def receive_photos():
         # Clean up on error
         if os.path.exists(process_dir):
             shutil.rmtree(process_dir)
-        return jsonify({'error': str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 500
 
 
 @main_bp.route('/api/process/<session_id>', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/sukitsubaki/pixTrail/security/code-scanning/2](https://github.com/sukitsubaki/pixTrail/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception information is not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and modifying the JSON response to return a generic error message.

1. Import the `traceback` module to capture the stack trace.
2. Use the `logging` module to log the detailed exception information.
3. Return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
