### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/pixtrail/web/routes.py
+++ b/pixtrail/web/routes.py
@@ -292,7 +292,8 @@ def cleanup_session(session_id):
             shutil.rmtree(session_dir)
             return jsonify({'success': True, 'message': 'Session cleaned up successfully'})
         except Exception as e:
-            return jsonify({'error': str(e)}), 500
+            current_app.logger.error('Error during session cleanup: %s', e)
+            return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
     
     return jsonify({'success': True, 'message': 'Nothing to clean up'})
 


### PR DESCRIPTION
Potential fix for [https://github.com/sukitsubaki/pixTrail/security/code-scanning/4](https://github.com/sukitsubaki/pixTrail/security/code-scanning/4)

To fix the problem, we should log the exception details on the server and return a generic error message to the user. This ensures that sensitive information is not exposed to the end user while still allowing developers to access the necessary details for debugging.

- Modify the exception handling block to log the exception using the `logging` module.
- Return a generic error message to the user instead of the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
